### PR TITLE
tiny fixes

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -4319,6 +4319,9 @@ void Aura::HandleAuraModStun(bool apply, bool Real)
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
         target->CastStop(target->GetObjectGuid() == GetCasterGuid() ? GetId() : 0);
 
+        // remove stealth when stunned
+        target->RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+
         // Creature specific
         if(target->GetTypeId() != TYPEID_PLAYER)
             target->StopMoving();

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -5688,7 +5688,8 @@ void Unit::AttackedBy(Unit* attacker)
 
     // trigger pet AI reaction
     if (Pet* pet = GetPet())
-        pet->AttackedBy(attacker);
+        if (this != attacker)
+            pet->AttackedBy(attacker);
 }
 
 bool Unit::AttackStop(bool targetSwitch /*=false*/)

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1612,7 +1612,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         {
             ShapeshiftForm form = GetShapeshiftForm();
             return form != FORM_NONE && form != FORM_BATTLESTANCE && form != FORM_BERSERKERSTANCE && form != FORM_DEFENSIVESTANCE &&
-                form != FORM_SHADOW;
+                form != FORM_SHADOW && form != FORM_STEALTH;
         }
 
         float m_modMeleeHitChance;


### PR DESCRIPTION
allow mounting while stealthed: http://getmangos.com/community/topic/17210/one-rogue-stealth/
dont let pet attack owner own self damage: http://getmangos.com/community/topic/17472/one-health-funnel-warlock-pets/
remove stealth when stunned: http://getmangos.com/community/topic/17209/one-rogue-sap/

as pull request since they are really small... should be "backported" to one and zero
