### PR TITLE
Apply ACE patches for FreeBSD

### DIFF
--- a/dep/ACE_wrappers/ace/OS_NS_Thread.h
+++ b/dep/ACE_wrappers/ace/OS_NS_Thread.h
@@ -38,6 +38,12 @@
 # include "ace/ACE_export.h"
 # include "ace/Object_Manager_Base.h"
 
+# include <sys/param.h>
+#if (defined(__FreeBSD__) && ((__FreeBSD_version >= 700110 && __FreeBSD_version < 800000) || __FreeBSD_version >= 800024))
+# include <sys/cpuset.h>
+# define cpu_set_t cpuset_t
+#endif
+
 # if defined (ACE_EXPORT_MACRO)
 #   undef ACE_EXPORT_MACRO
 # endif

--- a/dep/ACE_wrappers/ace/OS_NS_netdb.inl
+++ b/dep/ACE_wrappers/ace/OS_NS_netdb.inl
@@ -6,6 +6,8 @@
 #include "ace/OS_NS_string.h"
 #include "ace/OS_NS_errno.h"
 
+#include <sys/param.h>
+
 #if defined (ACE_LACKS_NETDB_REENTRANT_FUNCTIONS)
 # if defined (ACE_MT_SAFE) && (ACE_MT_SAFE != 0)
 #   define ACE_NETDBCALL_RETURN(OP,TYPE,FAILVALUE,TARGET,SIZE) \
@@ -125,7 +127,7 @@ ACE_OS::gethostbyaddr_r (const char *addr,
       *h_errnop = h_errno;
       return (struct hostent *) 0;
     }
-#   elif defined (__GLIBC__)
+#   elif defined (__GLIBC__) || (defined(__FreeBSD__) && __FreeBSD_version >= 700015)
   // GNU C library has a different signature
   ACE_OS::memset (buffer, 0, sizeof (ACE_HOSTENT_DATA));
 
@@ -317,7 +319,7 @@ ACE_OS::gethostbyname_r (const char *name,
       *h_errnop = h_errno;
       return (struct hostent *) 0;
     }
-#   elif defined (__GLIBC__)
+#   elif defined (__GLIBC__) || (defined(__FreeBSD__) && __FreeBSD_version >= 700015)
   // GNU C library has a different signature
   ACE_OS::memset (buffer, 0, sizeof (ACE_HOSTENT_DATA));
 
@@ -531,7 +533,7 @@ ACE_OS::getprotobyname_r (const char *name,
   else
     return 0;
   //FUZZ: enable check_for_lack_ACE_OS
-# elif defined (__GLIBC__)
+# elif defined (__GLIBC__) || (defined(__FreeBSD__) && __FreeBSD_version >= 700015)
   // GNU C library has a different signature
   //FUZZ: disable check_for_lack_ACE_OS
   if (::getprotobyname_r (name,
@@ -612,7 +614,7 @@ ACE_OS::getprotobynumber_r (int proto,
   //FUZZ: enable check_for_lack_ACE_OS
   else
     return 0;
-# elif defined (__GLIBC__)
+# elif defined (__GLIBC__) || (defined(__FreeBSD__) && __FreeBSD_version >= 700015)
   // GNU C library has a different signature
   //FUZZ: disable check_for_lack_ACE_OS
   if (::getprotobynumber_r (proto,
@@ -698,7 +700,7 @@ ACE_OS::getservbyname_r (const char *svc,
   //FUZZ: enable check_for_lack_ACE_OS
   else
     return (struct servent *) 0;
-# elif defined (__GLIBC__)
+# elif defined (__GLIBC__) || (defined(__FreeBSD__) && __FreeBSD_version >= 700015)
   // GNU C library has a different signature
   ACE_OS::memset (buf, 0, sizeof (ACE_SERVENT_DATA));
 

--- a/dep/ACE_wrappers/ace/OS_NS_signal.h
+++ b/dep/ACE_wrappers/ace/OS_NS_signal.h
@@ -33,10 +33,10 @@
 #endif
 #define ACE_EXPORT_MACRO ACE_Export
 
-#if defined (__Lynx__)
-// LynxOS defines pthread_sigmask() in pthread.h
+#if defined (__Lynx__) || defined (__OpenBSD__) || defined (__FreeBSD__)
+// LynxOS, OpenBSD and FreeBSD define pthread_sigmask() in pthread.h
 # include "ace/os_include/os_pthread.h"
-#endif /* __Lynx__ */
+#endif /* __Lynx__ || OpenBSD || FreeBSD */
 
 /*
  * We inline and undef some functions that may be implemented

--- a/dep/ACE_wrappers/ace/os_include/os_pthread.h
+++ b/dep/ACE_wrappers/ace/os_include/os_pthread.h
@@ -299,7 +299,11 @@
 #    undef THR_DAEMON
 
 #    define THR_BOUND               0x00000001
+# if defined (__FreeBSD__)
+#    define THR_NEW_LWP             0x00000000
+# else
 #    define THR_NEW_LWP             0x00000002
+# endif
 #    define THR_DETACHED            0x00000040
 #    define THR_SUSPENDED           0x00000080
 #    define THR_DAEMON              0x00000100

--- a/src/shared/revision_nr.h
+++ b/src/shared/revision_nr.h
@@ -1,4 +1,4 @@
 #ifndef __REVISION_NR_H__
 #define __REVISION_NR_H__
- #define REVISION_NR "12071"
+ #define REVISION_NR "12072"
 #endif // __REVISION_NR_H__


### PR DESCRIPTION
These patches are ported by me from the freebsd ports tree from ace 5.7.5 to the mangos bundled ace library 5.8.3. 
