### PR TITLE
Eliminate race condition in World Log.

### DIFF
--- a/src/shared/Log.cpp
+++ b/src/shared/Log.cpp
@@ -717,6 +717,8 @@ void Log::outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeNam
     if (!worldLogfile)
         return;
 
+    ACE_GUARD(ACE_Thread_Mutex, GuardObj, m_worldLogMtx);
+
     outTimestamp(worldLogfile);
 
     fprintf(worldLogfile, "\n%s:\nSOCKET: %u\nLENGTH: " SIZEFMTD "\nOPCODE: %s (0x%.4X)\nDATA:\n",

--- a/src/shared/Log.h
+++ b/src/shared/Log.h
@@ -170,6 +170,7 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, ACE_Th
         FILE* charLogfile;
         FILE* dberLogfile;
         FILE* worldLogfile;
+        ACE_Thread_Mutex m_worldLogMtx;
 
         // log/console control
         LogLevel m_logLevel;


### PR DESCRIPTION
In has been introduced with multithreaded packet processing, and prevents the dump from being written correctly, e.g. with tools.
