### PR TITLE
Print stack trace in ByteBufferException::PrintPosError.

### DIFF
--- a/src/shared/ByteBuffer.h
+++ b/src/shared/ByteBuffer.h
@@ -34,8 +34,11 @@ class ByteBufferException
 
         void PrintPosError() const
         {
-            sLog.outError("Attempted to %s in ByteBuffer (pos: " SIZEFMTD " size: "SIZEFMTD") value with size: " SIZEFMTD,
-                          (add ? "put" : "get"), pos, size, esize);
+            ACE_Stack_Trace trace;
+            sLog.outError(
+                "Attempted to %s in ByteBuffer (pos: " SIZEFMTD " size: "SIZEFMTD") "
+                "value with size: " SIZEFMTD "\n%s",
+                (add ? "put" : "get"), pos, size, esize, trace.c_str());
         }
     private:
         bool add;


### PR DESCRIPTION
Helps a lot when debugging new packet structures.
