### PR TITLE
Possibly fix ByteBuffer when no ACE_Stack_Trace available.

### DIFF
--- a/src/shared/ByteBuffer.h
+++ b/src/shared/ByteBuffer.h
@@ -34,11 +34,20 @@ class ByteBufferException
 
         void PrintPosError() const
         {
+            char const* traceStr;
+
+#ifdef HAVE_ACE_STACK_TRACE_H
             ACE_Stack_Trace trace;
+            traceStr = trace.c_str();
+#else
+            traceStr = NULL;
+#endif
+
             sLog.outError(
                 "Attempted to %s in ByteBuffer (pos: " SIZEFMTD " size: "SIZEFMTD") "
-                "value with size: " SIZEFMTD "\n%s",
-                (add ? "put" : "get"), pos, size, esize, trace.c_str());
+                "value with size: " SIZEFMTD "%s%s",
+                (add ? "put" : "get"), pos, size, esize,
+                traceStr ? "\n" : "", traceStr ? traceStr : "");
         }
     private:
         bool add;


### PR DESCRIPTION
Testing required as I do not have access to a system that lacks ACE_Stack_Trace.

Related: #62

Thanks to @VladimirMangos for the tip. Summoning @evil-at-wow & @Mentalow for testing, thanks.
