### PR TITLE
Fix building mangos using gcc 4.7.

### DIFF
--- a/dep/include/g3dlite/G3D/GMutex.h
+++ b/dep/include/g3dlite/G3D/GMutex.h
@@ -16,6 +16,7 @@
 #ifndef G3D_WIN32
 #   include <pthread.h>
 #   include <signal.h>
+#   include <unistd.h>
 #endif
 
 


### PR DESCRIPTION
This fixes mangos build with GCC 4.7.

(Sorry about the wrong commit timestamp.)

The error:

```
lordjz@debian:~/mangos/build$ cmake ../tree -DTBB_USE_EXTERNAL=0 -DCMAKE_C_COMPILER=gcc-4.7 -DCMAKE_CXX_COMPILER=g++-4.7 -DACE_USE_EXTERNAL=1
-- The C compiler identification is GNU 4.7.1
-- The CXX compiler identification is GNU 4.7.1
-- Check for working C compiler: /usr/bin/gcc-4.7
-- Check for working C compiler: /usr/bin/gcc-4.7 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++-4.7
-- Check for working CXX compiler: /usr/bin/g++-4.7 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detected 32-bit platform.
-- Found Git: /usr/bin/git

This script builds the MaNGOS server.
  Options that can be used in order to configure the process:
    PREFIX: Path where the server should be installed to
    PCH: Use precompiled headers
    DEBUG: Debug mode
  To set an option simply type -D<OPTION>=<VALUE> after 'cmake <srcs>'.
  For example: cmake .. -DDEBUG=1 -DPREFIX=/opt/mangos

-- Found ACE library: /usr/local/lib/libACE.so
-- Found ACE headers: /usr/local/include
-- Using mysql-config: /usr/bin/mysql_config
-- Found MySQL library: /usr/lib/i386-linux-gnu/libmysqlclient_r.so
-- Found MySQL headers: /usr/include/mysql
-- Found OpenSSL library: /usr/lib/i386-linux-gnu/libssl.so
-- Found OpenSSL headers: /usr/include/openssl
-- Found ZLIB: /usr/lib/i386-linux-gnu/libz.so (found version "1.2.7")

MaNGOS-Core revision  : afad47038b7c7814e94bc8dae72743429837431f

Install server to     : /home/lordjz/mangos/mangos-server

Use PCH               : No
Build in debug-mode   : No  (default)

-- Configuring done
-- Generating done
-- Build files have been written to: /home/lordjz/mangos/build
lordjz@debian:~/mangos/build$ make 2>&1 > /dev/null
In file included from /home/lordjz/mangos/tree/dep/include/g3dlite/G3D/Random.h:17:0,
                 from /home/lordjz/mangos/tree/dep/include/g3dlite/G3D/Vector3.h:19,
                 from /home/lordjz/mangos/tree/dep/include/g3dlite/G3D/AABox.h:19,
                 from /home/lordjz/mangos/tree/dep/src/g3dlite/AABox.cpp:11:
/home/lordjz/mangos/tree/dep/include/g3dlite/G3D/GMutex.h: In member function Б─≤bool G3D::Spinlock::lock()Б─≥:
/home/lordjz/mangos/tree/dep/include/g3dlite/G3D/GMutex.h:51:25: error: Б─≤usleepБ─≥ was not declared in this scope
make[2]: *** [dep/src/g3dlite/CMakeFiles/g3dlite.dir/AABox.cpp.o] Error 1
make[1]: *** [dep/src/g3dlite/CMakeFiles/g3dlite.dir/all] Error 2
make: *** [all] Error 2
lordjz@debian:~/mangos/build$ g++-4.7 -v
Using built-in specs.
COLLECT_GCC=g++-4.7
COLLECT_LTO_WRAPPER=/usr/lib/gcc/i486-linux-gnu/4.7/lto-wrapper
Target: i486-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 4.7.1-2' --with-bugurl=file:///usr/share/doc/gcc-4.7/README.Bugs --enable-languages=c,c++,go,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.7 --enable-shared --enable-linker-build-id --with-system-zlib --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.7 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --enable-plugin --enable-objc-gc --enable-targets=all --with-arch-32=i586 --with-tune=generic --enable-checking=release --build=i486-linux-gnu --host=i486-linux-gnu --target=i486-linux-gnu
Thread model: posix
gcc version 4.7.1 (Debian 4.7.1-2)
```
