### PR TITLE
Do not send SMSG_POWER_UPDATE if unit is not in world.

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -9340,11 +9340,14 @@ void Unit::SetPower(Powers power, uint32 val)
 
     SetStatInt32Value(UNIT_FIELD_POWER1 + power, val);
 
-    WorldPacket data(SMSG_POWER_UPDATE);
-    data << GetPackGUID();
-    data << uint8(power);
-    data << uint32(val);
-    SendMessageToSet(&data, true);
+    if (IsInWorld())
+    {
+        WorldPacket data(SMSG_POWER_UPDATE);
+        data << GetPackGUID();
+        data << uint8(power);
+        data << uint32(val);
+        SendMessageToSet(&data, true);
+    }
 
     // group update
     if (GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
This fixes opcode spam e.g. when creating new character.
