### PR TITLE
Update win/VC100/game.vcxproj.filters

### DIFF
--- a/win/VC100/game.vcxproj.filters
+++ b/win/VC100/game.vcxproj.filters
@@ -513,6 +513,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\game\CreatureLinkingMgr.cpp">
       <Filter>World/Handlers</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\game\DB2Stores.cpp">
       <Filter>Server</Filter>
     </ClCompile>


### PR DESCRIPTION
Added missing </ClCompile> tag on line 516, prevented file being loaded as part of project within Visual Studio 2012.
