### PR TITLE
Update sql/mangos.sql

### DIFF
--- a/sql/mangos.sql
+++ b/sql/mangos.sql
@@ -1365,7 +1365,7 @@ CREATE TABLE `creature_template` (
 LOCK TABLES `creature_template` WRITE;
 /*!40000 ALTER TABLE `creature_template` DISABLE KEYS */;
 INSERT INTO `creature_template` VALUES
-(1,0,0,0,0,0,10045,0,0,0,'Waypoint(Only GM can see it)','Visual',NULL,0,1,1,64,64,0,0,5,35,35,0,0.91,1.14286,1,0,2,3,0,10,1,2000,2200,8,4096,0,0,0,0,0,0,1,2,100,8,5242886,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,'',0,7,1,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,130,'');
+(1, 0, 0, 0, 0, 0, 10045, 0, 0, 0, 'Waypoint(Only GM can see it)', 'Visual', NULL, 0, 1, 1, 64, 64, 0, 0, 5, 35, 35, 0, 0.91, 1.14286, 1, 0, 2, 3, 0, 10, 1, 2000, 2200, 8, 4096, 0, 0, 0, 0, 0, 0, 0, 1, 2, 100, 8, 5242886, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 7, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 130, '');
 /*!40000 ALTER TABLE `creature_template` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
ERROR 1136 (21S01) at line 1367: Column count doesn't match value count at row 1
22:43 <+shlainn> a new field was added to the db in 12241
22:49 <+shlainn> (1, 0, 0, 0, 0, 0, 10045, 0, 0, 0, 'Waypoint(Only GM can see it)', 'Visual', NULL, 0, 1, 1, 64, 64, 0, 0, 5, 35, 35, 0, 0.91, 1.14286, 1, 0, 2, 3, 0, 10, 1, 2000, 2200, 8, 4096, 0, 0, 0, 0, 0, 0, 0, 1, 2, 100, 8, 5242886, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 7, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 130, '');
